### PR TITLE
Fixed error doesn't reset current and past members.

### DIFF
--- a/src/components/main/index.js
+++ b/src/components/main/index.js
@@ -18,7 +18,7 @@ class Main extends React.Component {
     .then(response => response.json())
     .then(json => {
       if(json.error){
-        this.setState({error: json.error})
+        this.setState({current: null, past: null, error: json.error})
       } else if(json[0].person){
         this.setState({person: json, past: []})
       } else {


### PR DESCRIPTION
Now when on a group's page, if a new search returns an error, the page displays the error.